### PR TITLE
Add support for keeping tasks relative to version-control root.

### DIFF
--- a/t.py
+++ b/t.py
@@ -255,6 +255,9 @@ def _build_parser():
     config = OptionGroup(parser, "Configuration Options")
     config.add_option("-l", "--list", dest="name", default="tasks",
                       help="work on LIST", metavar="LIST")
+    config.add_option("-u", "--vcs-rooted",
+                      action="store_true", dest="vcsrooted", default=False,
+                      help="determine list directory from version-control root")
     config.add_option("-t", "--task-dir", dest="taskdir", default="",
                       help="work on the lists in DIR", metavar="DIR")
     config.add_option("-d", "--delete-if-empty",
@@ -281,6 +284,27 @@ def _build_parser():
 def _main():
     """Run the command-line interface."""
     (options, args) = _build_parser().parse_args()
+
+    if options.vcsrooted:
+        # VCS list inspired by ack: http://beyondgrep.com/ack-2.14-single-file
+        vcsroots = re.compile("^(\.(bzr|git|hg|svn)|(_(darcs|sgbak))|CVS|RCS|SCCS)$")
+
+        root = os.path.abspath(os.sep)
+        options.taskdir = os.path.abspath('.')
+        while options.taskdir is not root:
+            found = False
+            for f in os.listdir(options.taskdir):
+                if vcsroots.match(os.path.basename(f)) is not None:
+                    found = True
+                    break
+
+            if found:
+                break
+            options.taskdir = os.path.abspath(os.path.join(options.taskdir, '..'))
+
+        if options.taskdir is root:
+            sys.stderr.write('The current directory is not under version control.\n')
+            return
 
     td = TaskDict(taskdir=options.taskdir, name=options.name)
     text = ' '.join(args).strip()


### PR DESCRIPTION
For many projects, it would be very convenient to have the task directory be the VCS root of the project. While you _could_ build a shell function to parse this out, having integrated support is much easier for users. This PR implements that functionality by setting taskdir to be the first parent directory containing a known VCS metadata directory.
