### PR TITLE
Fixes #7: Count on bash prompt does not work properly.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -173,7 +173,7 @@ Counting your tasks is simple using the `wc` program:
 
 Want a count of your tasks right in your prompt?  Edit your `~/.bashrc` file:
 
-    export PS1="[$(t | wc -l | sed -e's/ *//')] $PS1"
+    export PS1='[$(t | wc -l | sed -e"s/ *//")]'" $PS1"
 
 Now you've got a prompt that looks something like this:
 


### PR DESCRIPTION
Dynamic PS1 commands have to be wrapped in a single quote as opposed to a double quote. Otherwise they will only be run at the time of initiating the terminal or sourcing.