### PR TITLE
add printing of id after adding a task

### DIFF
--- a/t.py
+++ b/t.py
@@ -177,6 +177,9 @@ class TaskDict(object):
         task_id = _hash(text)
         self.tasks[task_id] = {'id': task_id, 'text': text}
 
+        prefixes = _prefixes(self.tasks)
+        print(prefixes[task_id])
+
     def edit_task(self, prefix, text):
         """Edit the task with the given prefix.
 


### PR DESCRIPTION
Implements the feature requested in #20.