### PR TITLE
Added ability to remove/finish multiple tasks (#12)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,6 +105,7 @@ To add a task, use `t [task description]`:
     $ t Clean the apartment.
     $ t Write chapter 10 of the novel.
     $ t Buy more beer.
+    $ t Write some code
     $
 
 ### List Your Tasks
@@ -115,6 +116,7 @@ Listing your tasks is even easier -- just use `t`:
     9  - Buy more beer.
     30 - Clean the apartment.
     31 - Write chapter 10 of the novel.
+    e  - Write some code
     $
 
 `t` will list all of your unfinished tasks and their IDs.
@@ -127,6 +129,10 @@ After you're done with something, use `t -f ID` to finish it:
     $ t
     9  - Buy more beer.
     30 - Clean the apartment.
+    e  - Write some code
+    $ t -f 9,30
+    $ t
+    e - Write some code
     $
 
 ### Edit a Task

--- a/t.py
+++ b/t.py
@@ -264,9 +264,9 @@ def _build_parser():
     actions.add_option("-e", "--edit", dest="edit", default="",
                        help="edit TASK to contain TEXT", metavar="TASK")
     actions.add_option("-f", "--finish", dest="finish",
-                       help="mark TASK as finished", metavar="TASK")
+                       help="mark TASK (t -f ID) or TASKS (t -f ID,ID) as finished", metavar="TASK")
     actions.add_option("-r", "--remove", dest="remove",
-                       help="Remove TASK from list", metavar="TASK")
+                       help="Remove TASK (t -r ID) or TASKS (t -r ID,ID) from list", metavar="TASK")
     parser.add_option_group(actions)
 
     config = OptionGroup(parser, "Configuration Options")

--- a/t.py
+++ b/t.py
@@ -7,6 +7,7 @@ from __future__ import with_statement, print_function
 import os, re, sys, hashlib
 from operator import itemgetter
 from optparse import OptionParser, OptionGroup
+from re import split as re_split
 
 
 class InvalidTaskfile(Exception):
@@ -195,27 +196,28 @@ class TaskDict(object):
         task['text'] = text
         task['id'] = _hash(text)
 
-    def finish_task(self, prefix):
-        """Mark the task with the given prefix as finished.
+    def finish_task(self, prefix_list):
+        """Mark tasks with the given prefix as finished.
 
         If more than one task matches the prefix an AmbiguousPrefix exception
         will be raised, if no tasks match it an UnknownPrefix exception will
         be raised.
 
         """
-        task = self.tasks.pop(self[prefix]['id'])
-        self.done[task['id']] = task
+        for prefix in re_split(",", prefix_list):
+            task = self.tasks.pop(self[prefix]['id'])
+            self.done[task['id']] = task
 
-    def remove_task(self, prefix):
-        """Remove the task from tasks list.
+    def remove_task(self, prefix_list):
+        """Remove tasks from tasks list.
 
         If more than one task matches the prefix an AmbiguousPrefix exception
         will be raised, if no tasks match it an UnknownPrefix exception will
         be raised.
 
         """
-        self.tasks.pop(self[prefix]['id'])
-
+        for prefix in re_split(",", prefix_list):
+            self.tasks.pop(self[prefix]['id'])
 
     def print_list(self, kind='tasks', verbose=False, quiet=False, grep=''):
         """Print out a nicely formatted list of unfinished tasks."""


### PR DESCRIPTION
Adds #12. Remove multiple tasks using a comma-separated list of IDs. (e.g. `t -f 31,3f,e`).

Also changed `--help` messages and the README to accommodate for the changes.