### PR TITLE
Minor tweaks

### DIFF
--- a/t.py
+++ b/t.py
@@ -160,6 +160,8 @@ class TaskDict(object):
         If no tasks match the prefix an UnknownPrefix exception will be raised.
 
         """
+
+        prefix = prefix.strip().lower()
         matched = [tid for tid in self.tasks.keys() if tid.startswith(prefix)]
         if len(matched) == 1:
             return self.tasks[matched[0]]

--- a/t.py
+++ b/t.py
@@ -95,7 +95,7 @@ def _prefixes(ids):
     ps = {}
     for id in ids:
         id_len = len(id)
-        for i in range(1, id_len+1):
+        for i in range(3, id_len+1):
             # identifies an empty prefix slot, or a singular collision
             prefix = id[:i]
             if (not prefix in ps) or (ps[prefix] and prefix != ps[prefix]):


### PR DESCRIPTION
The first commit actually fixes a bug and the second is just a personal preference.

```
t.py -f "  0a0  " would fail without .strip()      # don't ask how I got into this error, it's been a while

t.py -f "0A0" would fail without .lower()      # this happened to me just today
```

The second commit causes t.py to always display at least three characters of the hash. I have so many tasks that most of the hashes need to be three characters long to be unique so I threw this in there just for aesthetic reasons. It looks cleaner to me. Ymmv.