### PR TITLE
A t version with chronologically sortable (and obfuscated) b62 ids that will keep tasks file sorted

### DIFF
--- a/.bugs.done
+++ b/.bugs.done
@@ -1,5 +1,0 @@
-Add some documentation. | id:099d5d22044eee4858835037431e409ba67c6db4
-Add a license. | id:931f182337038062f181f122c48ffc870a028767
-Add a quiet mode. | id:b1d61f718eec29cba4ee55b56a067a79959c5d42
-Add creation date to metadata. | id:e9866e56460791b864fe3db0c6cd0610ba436f77
-Add ordering. | id:f3a326db186e503793182027f1663098c86d5d5f

--- a/t.py
+++ b/t.py
@@ -7,6 +7,10 @@ from __future__ import with_statement, print_function
 import os, re, sys, hashlib
 from operator import itemgetter
 from optparse import OptionParser, OptionGroup
+from uuid_utils import uuid7, UUID
+from itertools import starmap
+from pdb import set_trace
+import time
 
 
 class InvalidTaskfile(Exception):
@@ -32,16 +36,116 @@ class BadFile(Exception):
         self.path = path
         self.problem = problem
 
-
 def _hash(text):
-    """Return a hash of the given text for use as an id.
+    """Return a hash of the given text for use to retrieve tasks by ID.
 
     Currently SHA1 hashing is used.  It should be plenty for our purposes.
 
     """
     return hashlib.sha1(text.encode('utf-8')).hexdigest()
 
-def _task_from_taskline(taskline):
+def _id():
+    """Return a new unique ID chronologically sortable for a task."""
+    return uuid7().hex
+
+def _parse_text_and_metadata_from_taskline(line: str):
+    text, sep, content = line.partition('|')
+    return (text.strip(), content.strip()) if sep else (line.strip(), None)
+
+def _sort_ids(p_id, c_id, n_id):
+    """Return the sorted order of the given IDs, ignoring None values."""
+    ids = [i for i in (p_id, c_id, n_id) if i is not None]
+    ids.sort()
+    return ids
+
+def _task_based_on_neighbour_lines(c_line: str, p_line: str, n_line: str) -> tuple[dict, dict, dict]:
+    def _delta_task_id(task_id : str, increase = True, next_task_id = ''):
+        start = UUID(task_id)
+        time.sleep(0.025) # increase difference between UUIDs
+        before = UUID(_id())
+        after = (UUID(_id()).int - before.int) % (1 << 32)\
+                if not next_task_id else \
+                (UUID(next_task_id).int - start.int) %  (1 << 32) // 2
+        return UUID(
+                int = start.int + (after if increase else -after)
+        ).hex
+
+    """
+    Given the current, previous and next tasklines, return the current tasks
+    taking into account the neighbour states.
+    """
+    c = _build_task(
+            *_parse_text_and_metadata_from_taskline(c_line)
+            )
+    p = _build_task(
+            *_parse_text_and_metadata_from_taskline(p_line)
+            ) if p_line else dict()
+    n = _build_task(
+            *_parse_text_and_metadata_from_taskline(n_line)
+            ) if n_line else dict()
+    c_id = c.get('id', None)
+    p_id = p.get('id', None)
+    n_id = n.get('id', None)
+
+    match (
+            c_id is not None,
+            p_id is not None,
+            n_id is not None
+            ):
+        # None, None, None which means new task
+        case [False, False, False]: 
+            c['id'] = _id()
+        # Has previous and next tasks with IDs, so we can generate
+        # a new ID and assign it in order to current, previous and next
+        # while keeping the order
+        case [False, True, True]:
+            c_id = _delta_task_id(
+                    p_id,
+                    increase=True,
+                    next_task_id=n_id
+            )
+            p['id'], c['id'], n['id'] = _sort_ids(p_id, c_id, n_id)
+        # Has previous task without ID, but current and next both have IDs
+        case [True, False, True]:
+            p_id = _delta_task_id(c_id, increase=False)
+            p['id'], c['id'], n['id'] = _sort_ids(p_id, c_id, n_id)
+        # Has next task without ID, but current and previous both have IDs
+        case [True, True, False]:
+            n_id = _delta_task_id(c_id, increase=True)
+            p['id'], c['id'], n['id'] = _sort_ids(p_id, c_id, n_id)
+        # Has only current task with ID, so we generate two new IDs.
+        # from the current one, making previous smaller and next larger.
+        case [True, False, False]:
+            p_id = _delta_task_id(c_id, increase=False)
+            n_id = _delta_task_id(c_id, increase=True)
+            p['id'], c['id'], n['id'] = p_id, c_id, n_id
+        # Has only previous task with ID, so we generate two new IDs.
+        case [False, True, False]:
+            c_id = _delta_task_id(p_id, increase=True)
+            n_id = _delta_task_id(c_id, increase=True)
+            p['id'], c['id'], n['id'] = p_id, c_id, n_id
+        # Has only next task with ID, so we generate two new IDs.
+        # from the next one, making current smaller and previous even smaller.
+        case [False, False, True]:
+            c_id = _delta_task_id(n_id, increase=False)
+            p_id = _delta_task_id(c_id, increase=False)
+            p['id'], c['id'], n['id'] = p_id, c_id, n_id
+        # If everyone has IDs, we order them only to keep consistency
+        case [True, True, True]:
+            p['id'], c['id'], n['id'] = _sort_ids(p_id, c_id, n_id)
+
+    return (c, p, n)
+
+def _build_task(text, metadata = None):
+    task = { 'text': text }
+    if metadata:
+        for piece in metadata.strip().split(','):
+            label, data = piece.split(':')
+            task[label.strip()] = data.strip()
+    return task
+
+
+def _task_from_taskline(current_line, previous_line, next_line):
     """Parse a taskline (from a task file) and return a task.
 
     A taskline should be in the format:
@@ -54,33 +158,48 @@ def _task_from_taskline(taskline):
           'text': <summary text>,
            ... other metadata ... }
 
+    We'll also return updated versions of current_line, previous_line
+    and next_line to reflect any modifications performed to keep IDs
+    consistent and ordered.
+
     A taskline can also consist of only summary text, in which case the id
     and other metadata will be generated when the line is read.  This is
     supported to enable editing of the taskfile with a simple text editor.
     """
-    if taskline.strip().startswith('#'):
-        return None
-    elif '|' in taskline:
-        text, _, meta = taskline.rpartition('|')
-        task = { 'text': text.strip() }
-        for piece in meta.strip().split(','):
-            label, data = piece.split(':')
-            task[label.strip()] = data.strip()
-    else:
-        text = taskline.strip()
-        task = { 'id': _hash(text), 'text': text }
-    return task
+    if current_line.strip().startswith('#'): # Skip comments
+        return [ None ] * 4
+    """
+    Current task should always reflect neighbour states, so we can keep IDs
+    consistent and ordered even if the taskfile is edited manually.
+    """
+    c, p, n = _task_based_on_neighbour_lines(
+            current_line,
+            previous_line,
+            next_line
+            )
+
+    previous_line = _taskline_from_task(p) if 'text' in p else previous_line
+    next_line = _taskline_from_task(n) if 'text' in n else next_line
+    current_line = _taskline_from_task(c)
+
+    """
+        We'll also update current_line, previous_line and next_line to
+        reflect any modifications possibly performed
+    """
+    return c, current_line, previous_line, next_line
+
+def _taskline_from_task(task):
+    """Parse a task into a taskline suitable for writing."""
+    meta = [m for m in task.items() if m[0] != 'text']
+    meta_str = ', '.join('%s:%s' % m for m in meta)
+    return '%s | %s\n' % (task['text'], meta_str)
 
 def _tasklines_from_tasks(tasks):
     """Parse a list of tasks into tasklines suitable for writing."""
 
-    tasklines = []
-
-    for task in tasks:
-        meta = [m for m in task.items() if m[0] != 'text']
-        meta_str = ', '.join('%s:%s' % m for m in meta)
-        tasklines.append('%s | %s\n' % (task['text'], meta_str))
-
+    tasklines = [
+            _taskline_from_task(task) for task in tasks
+            ]
     return tasklines
 
 def _prefixes(ids):
@@ -121,6 +240,85 @@ def _prefixes(ids):
         del ps['']
     return ps
 
+def _summary_line(taskline):
+    """Return if a line is a summary line"""
+    _, sep, _ = taskline.partition('|')
+    return sep == ''
+
+def _ensure_tasklines_consistency(tls):
+    """
+    Ensure that after a summary line is found, all subsequent lines will
+    be transformed into summary lines, so every task has a unique and 
+    sortable ID.
+    """
+    summary_lines = list(map(_summary_line, tls))
+    summary_idx = summary_lines.index(True) if True in summary_lines else -1
+    if summary_idx != -1:
+        for i in range(summary_idx, len(tls)):
+            if not _summary_line(tls[i]):
+                text, _ = _parse_text_and_metadata_from_taskline(tls[i])
+                tls[i] = text
+    return tls
+
+def _handle_tasks(tls, past_shifted_tls, future_shifted_tls):
+    """
+    Given a list of tasklines, return the corresponding tasks.
+    We'll also perform modifications to the tasklines to keep IDs consistent
+    and ordered based on neighbour states.
+    """ 
+    tasks = []
+    number_of_tasks = len(tls)
+    for i in range(number_of_tasks):
+        c_line = tls[i]
+        p_line = past_shifted_tls[i]
+        n_line = future_shifted_tls[i]
+        task, c_line, p_line, n_line = _task_from_taskline(
+            c_line, p_line, n_line
+        )
+        tls[i] = c_line
+        past_shifted_tls[i] = p_line
+        # bind current line to the next past shifted line
+        past_shifted_tls[
+            (i + 1) % number_of_tasks
+        ] = c_line
+        future_shifted_tls[i] = n_line
+        tasks.append(task)
+
+    return tasks, tls, past_shifted_tls, future_shifted_tls
+
+def _task_from_taskline_simple(line, tasks_hashes_id_map):
+    """Parse a taskline (from a task file) and return a task.
+
+    A taskline should be in the format:
+
+        summary text ... | meta1:meta1_value,meta2:meta2_value,...
+
+    The task returned will be a dictionary such as:
+
+        { 'id': <hash id>,
+          'text': <summary text>,
+           ... other metadata ... }
+
+    """
+    if line.strip().startswith('#'): # Skip comments
+        return None
+    text, metadata = _parse_text_and_metadata_from_taskline(line)
+    task = _build_task(text, metadata)
+    if 'id' not in task:
+        task['id'] = tasks_hashes_id_map.get(_hash(text)) or _id()
+        tasks_hashes_id_map[_hash(text)] = task['id']
+    return task
+
+def _handle_tasks_simple(tls, tasks_hashes_id_map):
+    """
+    Given a list of properly consistent tasklines, return the corresponding tasks.
+    """
+    tasks = []
+    for line in tls:
+        task = _task_from_taskline_simple(line, tasks_hashes_id_map)
+        tasks += [task] if task not in tasks else []
+    return tasks
+
 
 class TaskDict(object):
     """A set of tasks, both finished and unfinished, for a given list.
@@ -132,6 +330,7 @@ class TaskDict(object):
     def __init__(self, taskdir='.', name='tasks'):
         """Initialize by reading the task files, if they exist."""
         self.tasks = {}
+        self.tasks_hashes_id_map = {}
         self.done = {}
         self.name = name
         self.taskdir = taskdir
@@ -144,12 +343,34 @@ class TaskDict(object):
                 try:
                     with open(path, 'r') as tfile:
                         tls = [tl.strip() for tl in tfile if tl]
-                        tasks = map(_task_from_taskline, tls)
+                        tls = _ensure_tasklines_consistency(tls)
+                        # Simple version without neighbour-based ID consistency
+                        tasks = _handle_tasks_simple(
+                            tls,
+                            self.tasks_hashes_id_map
+                        )
+                        '''
+                        dumb-fuckery
+                        past_shifted_tls = [''] + tls[:-1]
+                        future_shifted_tls = tls[1:] + ['']
+                        tasks, tls, past_shifted_tls, future_shifted_tls = _handle_tasks(
+                            tls,
+                            past_shifted_tls,
+                            future_shifted_tls
+                        )
+                        '''
                         for task in tasks:
                             if task is not None:
+                                # 1. Add task to self.tasks dict if it
+                                # is unfinished (kind == 'tasks')
                                 getattr(self, kind)[task['id']] = task
+                                # 2. Map hash of text to id to avoid task duplication
+                                self.tasks_hashes_id_map[_hash(task['text'])] = task['id']
                 except IOError as e:
                     raise BadFile(path, e.strerror)
+        # then we call self.write() to flush any changes back out
+        # to disk when needed
+        self.write()
 
     def __getitem__(self, prefix):
         """Return the unfinished task with the given prefix.
@@ -172,7 +393,7 @@ class TaskDict(object):
 
     def add_task(self, text, verbose, quiet):
         """Add a new, unfinished task with the given summary text."""
-        task_id = _hash(text)
+        task_id = self.tasks_hashes_id_map.get(_hash(text)) or _id()
         self.tasks[task_id] = {'id': task_id, 'text': text}
 
         if not quiet:
@@ -198,7 +419,7 @@ class TaskDict(object):
             text = re.sub(find, repl, task['text'])
 
         task['text'] = text
-        task['id'] = _hash(text)
+        # we should keep our ID, so we won't change it
 
     def finish_task(self, prefix):
         """Mark the task with the given prefix as finished.
@@ -267,7 +488,7 @@ def _build_parser():
     parser = OptionParser(usage=usage)
 
     actions = OptionGroup(parser, "Actions",
-        "If no actions are specified the TEXT will be added as a new task.")
+                          "If no actions are specified the TEXT will be added as a new task.")
     actions.add_option("-e", "--edit", dest="edit", default="",
                        help="edit TASK to contain TEXT", metavar="TASK")
     actions.add_option("-f", "--finish", dest="finish",


### PR DESCRIPTION
Currently, task identifiers are generated using md5sum hashes. Since these hashes are not chronologically sortable, every time a new task is added it can end up in an arbitrary position in the task file.

To address this, I propose replacing the hash-based IDs with a monotonically increasing counter encoded in an obfuscated base62 ([0–9A–Z–a–z]) base. The counter starts at 62², so all generated IDs have at least three base62 digits, and is incremented every time a new task is created.

To preserve the IDs of existing tasks, I implemented a lookup table that maps each task’s hash to its current ID. When a task is processed, its hash is checked in this table:

if it already exists, the existing ID is reused;

if it does not exist, a new obfuscated base62 ID is generated from the counter, assigned to the task, and recorded in the lookup table.

For “summary line” tasks (those that can be added directly in a text editor without metadata), the first occurrence of such a task receives the next available ID (greater than all previous IDs). All subsequent tasks that follow this summary line receive IDs that are incremented from that point, ensuring that the chronological order of tasks in the file is consistent with their IDs.